### PR TITLE
Fabric api call retries and additional fixes

### DIFF
--- a/src/FabricDiscovery.Core/Service/TopologyDiscovery/TopologyDiscoveryWorker.cs
+++ b/src/FabricDiscovery.Core/Service/TopologyDiscovery/TopologyDiscoveryWorker.cs
@@ -57,10 +57,12 @@ namespace IslandGateway.FabricDiscovery.Topology
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.operationLogger = operationLogger ?? throw new ArgumentNullException(nameof(operationLogger));
 
+            var iterationDelay = new JitteredTimeSpan(TimeSpan.FromSeconds(1), TimeSpan.Zero);
             this.recurringTask = new RecurringTask(this.RunIterationAsync)
                 .WithLogging(logger, operationLogger, "TopologyDiscoveryWorker.Iteration")
                 .WithAbortOnConsecutiveFailures(options.Value.AbortAfterConsecutiveFailures)
-                .WithIterationDelay(new JitteredTimeSpan(TimeSpan.FromSeconds(1), TimeSpan.Zero)) // Future: react when dirty services are added
+                .WithIterationDelay(iterationDelay) // Future: react when dirty services are added
+                .WithRetryDelay(iterationDelay)
                 .WithIterationTimeout(options.Value.AbortAfterTimeoutInSeconds > 0 ? TimeSpan.FromSeconds(options.Value.AbortAfterTimeoutInSeconds) : null);
         }
 

--- a/src/FabricUtil/FabricWrapper/ExceptionsHelper.cs
+++ b/src/FabricUtil/FabricWrapper/ExceptionsHelper.cs
@@ -38,49 +38,5 @@ namespace IslandGateway.ServiceFabricIntegration
                 throw;
             }
         }
-
-        /// <summary>
-        /// Translates Service Fabric's <see cref="FabricTransientException"/>
-        /// into the appropriate <see cref="OperationCanceledException"/> when it represents a deliberate cancellation.
-        /// </summary>
-        public static async Task<TResult> TranslateCancellations<TResult, TState>(Func<TState, Task<TResult>> func, TState state, CancellationToken cancellation)
-        {
-            try
-            {
-                return await func(state);
-            }
-            catch (FabricTransientException ex)
-            {
-                if (ex.ErrorCode == FabricErrorCode.OperationCanceled && cancellation.IsCancellationRequested)
-                {
-                    cancellation.ThrowIfCancellationRequested();
-                    throw new InvalidOperationException("Execution should never get here...");
-                }
-
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Translates Service Fabric's <see cref="FabricTransientException"/>
-        /// into the appropriate <see cref="OperationCanceledException"/> when it represents a deliberate cancellation.
-        /// </summary>
-        public static async Task TranslateCancellations<TState>(Func<TState, Task> func, TState state, CancellationToken cancellation)
-        {
-            try
-            {
-                await func(state);
-            }
-            catch (FabricTransientException ex)
-            {
-                if (ex.ErrorCode == FabricErrorCode.OperationCanceled && cancellation.IsCancellationRequested)
-                {
-                    cancellation.ThrowIfCancellationRequested();
-                    throw new InvalidOperationException("Execution should never get here...");
-                }
-
-                throw;
-            }
-        }
     }
 }

--- a/src/FabricUtil/FabricWrapper/FabricCallHelper.cs
+++ b/src/FabricUtil/FabricWrapper/FabricCallHelper.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Fabric;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IslandGateway.ServiceFabricIntegration
+{
+    /// <summary>
+    /// Helps translate Service Fabric aborted exceptions to standard types.
+    /// </summary>
+    public static class FabricCallHelper
+    {
+        /// <summary>
+        /// Executes the provided <paramref name="func"/> and retries according to the specified <paramref name="retryPolicy"/> on transient errors,
+        /// also taking care of translating deliberate cancellation exceptions.
+        /// </summary>
+        /// <param name="func">Function to be invoked with retries. The first argument specifies the current attempt number, starting from 1.</param>
+        /// <param name="retryPolicy">The retry policy to follow.</param>
+        /// <param name="cancellation">Cancellation token.</param>
+        public static async Task<TResult> RunWithExponentialRetries<TResult>(Func<int, CancellationToken, Task<TResult>> func, FabricExponentialRetryPolicy retryPolicy, CancellationToken cancellation)
+        {
+            int attempt = 0;
+            while (true)
+            {
+                cancellation.ThrowIfCancellationRequested();
+
+                attempt++;
+                try
+                {
+                    return await func(attempt, cancellation);
+                }
+                catch (Exception ex) when (ex is FabricTransientException || ex is TimeoutException)
+                {
+                    if (ex is FabricTransientException transientException &&
+                        transientException.ErrorCode == FabricErrorCode.OperationCanceled &&
+                        cancellation.IsCancellationRequested)
+                    {
+                        // Explicit cancellation requested by the called...
+                        cancellation.ThrowIfCancellationRequested();
+                        throw new InvalidOperationException("Execution should never get here...");
+                    }
+
+                    if (retryPolicy.IsRetryAllowed(attempt, out int backoffBeforeNextAttempt))
+                    {
+                        await Task.Delay(backoffBeforeNextAttempt, cancellation);
+                        continue;
+                    }
+
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/src/FabricUtil/FabricWrapper/FabricExponentialRetryPolicy.cs
+++ b/src/FabricUtil/FabricWrapper/FabricExponentialRetryPolicy.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace IslandGateway.ServiceFabricIntegration
+{
+    /// <summary>
+    /// Structure providing the defaults for SF retry policy.
+    /// </summary>
+    public struct FabricExponentialRetryPolicy
+    {
+        /// <summary>
+        /// Default intance of the policy.
+        /// </summary>
+        public static readonly FabricExponentialRetryPolicy Default = new()
+        {
+            NumAttempts = 3,
+            InitialBackoffMs = 1000,
+            MaxBackoffMs = 15000,
+        };
+
+        /// <summary>
+        /// Total number of attempts allowed in the retry policy.
+        /// </summary>
+        public uint NumAttempts { get; init; }
+
+        /// <summary>
+        /// Initial retry backoff.
+        /// </summary>
+        public uint InitialBackoffMs { get; init; }
+
+        /// <summary>
+        /// Maximum time allowed for a backoff.
+        /// </summary>
+        public uint MaxBackoffMs { get; init; }
+
+        /// <summary>
+        /// Helper function to determine whether retry may be allowed by policy.
+        /// On positive evaluation, next backoff is populated appropriately.
+        /// </summary>
+        /// <param name="attempt">Current attempt. Must be >= 1.</param>
+        /// <param name="backoffBeforeNextAttempt">The next backoff.</param>
+        /// <returns>Boolean whether retry is allowed by policy.</returns>
+        public bool IsRetryAllowed(int attempt, out int backoffBeforeNextAttempt)
+        {
+            backoffBeforeNextAttempt = default;
+            if (attempt <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(attempt));
+            }
+            if (attempt < this.NumAttempts)
+            {
+                backoffBeforeNextAttempt = (int)Math.Min((Math.Pow(2, attempt) - 1) * this.InitialBackoffMs, this.MaxBackoffMs);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/FabricUtil/FabricWrapper/QueryClientWrapper.cs
+++ b/src/FabricUtil/FabricWrapper/QueryClientWrapper.cs
@@ -41,23 +41,24 @@ namespace IslandGateway.FabricDiscovery.FabricWrapper
             int pageIndex = 0;
             do
             {
-                // TODO: Retry
-                var page = await this.operationLogger.ExecuteAsync(
-                    "FabricApi.GetApplicationTypePagedListAsync",
-                    () => ExceptionsHelper.TranslateCancellations(
-                        func: static state => state.queryClient.GetApplicationTypePagedListAsync(
-                            queryDescription: state.query,
-                            timeout: state.eachApiCallTimeout,
-                            cancellationToken: state.cancellationToken),
-                        state: (this.queryClient, query, eachApiCallTimeout, cancellationToken),
-                        cancellation: cancellationToken),
-                    new[]
-                    {
-                        KeyValuePair.Create(nameof(query.ApplicationTypeNameFilter), query.ApplicationTypeNameFilter ?? string.Empty),
-                        KeyValuePair.Create(nameof(query.ApplicationTypeVersionFilter), query.ApplicationTypeVersionFilter ?? string.Empty),
-                        KeyValuePair.Create("page", (pageIndex++).ToString()),
-                    });
+                var page = await FabricCallHelper.RunWithExponentialRetries(
+                    (attempt, cancellationToken) => this.operationLogger.ExecuteAsync(
+                        "FabricApi.GetApplicationTypePagedListAsync",
+                        () => this.queryClient.GetApplicationTypePagedListAsync(
+                            queryDescription: query,
+                            timeout: eachApiCallTimeout,
+                            cancellationToken: cancellationToken),
+                        new[]
+                        {
+                            KeyValuePair.Create(nameof(query.ApplicationTypeNameFilter), query.ApplicationTypeNameFilter ?? string.Empty),
+                            KeyValuePair.Create(nameof(query.ApplicationTypeVersionFilter), query.ApplicationTypeVersionFilter ?? string.Empty),
+                            KeyValuePair.Create("page", pageIndex.ToString()),
+                            KeyValuePair.Create("attempt", attempt.ToString()),
+                        }),
+                    FabricExponentialRetryPolicy.Default,
+                    cancellationToken);
 
+                pageIndex++;
                 foreach (var item in page)
                 {
                     yield return new ApplicationTypeWrapper
@@ -82,23 +83,24 @@ namespace IslandGateway.FabricDiscovery.FabricWrapper
             int pageIndex = 0;
             do
             {
-                // TODO: Retry
-                var page = await this.operationLogger.ExecuteAsync(
-                    "FabricApi.GetApplicationPagedListAsync",
-                    () => ExceptionsHelper.TranslateCancellations(
-                        func: static state => state.queryClient.GetApplicationPagedListAsync(
-                            applicationQueryDescription: state.query,
-                            timeout: state.eachApiCallTimeout,
-                            cancellationToken: state.cancellationToken),
-                        state: (this.queryClient, query, eachApiCallTimeout, cancellationToken),
-                        cancellation: cancellationToken),
-                    new[]
-                    {
-                        KeyValuePair.Create(nameof(query.ApplicationTypeNameFilter), query.ApplicationTypeNameFilter ?? string.Empty),
-                        KeyValuePair.Create(nameof(query.ApplicationNameFilter), query.ApplicationNameFilter != null ? query.ApplicationNameFilter.ToString() : string.Empty),
-                        KeyValuePair.Create("page", (pageIndex++).ToString()),
-                    });
+                var page = await FabricCallHelper.RunWithExponentialRetries(
+                    (attempt, cancellationToken) => this.operationLogger.ExecuteAsync(
+                        "FabricApi.GetApplicationPagedListAsync",
+                        () => this.queryClient.GetApplicationPagedListAsync(
+                            applicationQueryDescription: query,
+                            timeout: eachApiCallTimeout,
+                            cancellationToken: cancellationToken),
+                        new[]
+                        {
+                            KeyValuePair.Create(nameof(query.ApplicationTypeNameFilter), query.ApplicationTypeNameFilter ?? string.Empty),
+                            KeyValuePair.Create(nameof(query.ApplicationNameFilter), query.ApplicationNameFilter != null ? query.ApplicationNameFilter.ToString() : string.Empty),
+                            KeyValuePair.Create("page", pageIndex.ToString()),
+                            KeyValuePair.Create("attempt", attempt.ToString()),
+                        }),
+                    FabricExponentialRetryPolicy.Default,
+                    cancellationToken);
 
+                pageIndex++;
                 foreach (var item in page)
                 {
                     yield return new ApplicationWrapper
@@ -118,19 +120,21 @@ namespace IslandGateway.FabricDiscovery.FabricWrapper
         /// <inheritdoc/>
         public virtual async Task<ApplicationNameKey> GetApplicationNameAsync(ServiceNameKey serviceName, TimeSpan timeout, CancellationToken cancellationToken)
         {
-            var result = await this.operationLogger.ExecuteAsync(
-                "FabricApi.GetApplicationNameAsync",
-                () => ExceptionsHelper.TranslateCancellations(
-                    func: static state => state.queryClient.GetApplicationNameAsync(
-                        serviceName: state.serviceName,
-                        timeout: state.timeout,
-                        cancellationToken: state.cancellationToken),
-                    state: (this.queryClient, serviceName, timeout, cancellationToken),
-                    cancellation: cancellationToken),
-                new[]
-                {
-                    KeyValuePair.Create(nameof(serviceName), serviceName.ToString() ?? string.Empty),
-                });
+            var result = await FabricCallHelper.RunWithExponentialRetries(
+                (attempt, cancellationToken) => this.operationLogger.ExecuteAsync(
+                    "FabricApi.GetApplicationNameAsync",
+                    () => this.queryClient.GetApplicationNameAsync(
+                            serviceName: serviceName,
+                            timeout: timeout,
+                            cancellationToken: cancellationToken),
+                    new[]
+                    {
+                        KeyValuePair.Create(nameof(serviceName), serviceName.ToString() ?? string.Empty),
+                        KeyValuePair.Create("attempt", attempt.ToString()),
+                    }),
+                FabricExponentialRetryPolicy.Default,
+                cancellationToken);
+
             return new ApplicationNameKey(result.ApplicationName);
         }
 
@@ -146,23 +150,23 @@ namespace IslandGateway.FabricDiscovery.FabricWrapper
                 throw new ArgumentException(nameof(applicationTypeVersion));
             }
 
-            // TODO: Retry
-            var results = await this.operationLogger.ExecuteAsync(
-                "FabricApi.GetServiceTypeListAsync",
-                () => ExceptionsHelper.TranslateCancellations(
-                    func: static state => state.queryClient.GetServiceTypeListAsync(
-                        applicationTypeName: state.applicationTypeName,
-                        applicationTypeVersion: state.applicationTypeVersion,
+            var results = await FabricCallHelper.RunWithExponentialRetries(
+                (attempt, cancellationToken) => this.operationLogger.ExecuteAsync(
+                    "FabricApi.GetServiceTypeListAsync",
+                    () => this.queryClient.GetServiceTypeListAsync(
+                        applicationTypeName: applicationTypeName,
+                        applicationTypeVersion: applicationTypeVersion,
                         serviceTypeNameFilter: null,
-                        timeout: state.eachApiCallTimeout,
-                        cancellationToken: state.cancellationToken),
-                    state: (this.queryClient, applicationTypeName, applicationTypeVersion, eachApiCallTimeout, cancellationToken),
-                    cancellation: cancellationToken),
-                new[]
-                {
-                    KeyValuePair.Create(nameof(applicationTypeName), applicationTypeName.ToString() ?? string.Empty),
-                    KeyValuePair.Create(nameof(applicationTypeVersion), applicationTypeVersion.ToString() ?? string.Empty),
-                });
+                        timeout: eachApiCallTimeout,
+                        cancellationToken: cancellationToken),
+                    new[]
+                    {
+                        KeyValuePair.Create(nameof(applicationTypeName), applicationTypeName.ToString() ?? string.Empty),
+                        KeyValuePair.Create(nameof(applicationTypeVersion), applicationTypeVersion.ToString() ?? string.Empty),
+                        KeyValuePair.Create("attempt", attempt.ToString()),
+                    }),
+                FabricExponentialRetryPolicy.Default,
+                cancellationToken);
 
             foreach (var item in results)
             {
@@ -185,23 +189,24 @@ namespace IslandGateway.FabricDiscovery.FabricWrapper
             int pageIndex = 0;
             do
             {
-                // TODO: Retry
-                var page = await this.operationLogger.ExecuteAsync(
-                    "FabricApi.GetServicePagedListAsync",
-                    () => ExceptionsHelper.TranslateCancellations(
-                        func: static state => state.queryClient.GetServicePagedListAsync(
-                            serviceQueryDescription: state.query,
-                            timeout: state.eachApiCallTimeout,
-                            cancellationToken: state.cancellationToken),
-                        state: (this.queryClient, query, eachApiCallTimeout, cancellationToken),
-                        cancellation: cancellationToken),
-                    new[]
-                    {
-                        KeyValuePair.Create(nameof(query.ServiceTypeNameFilter), query.ServiceTypeNameFilter ?? string.Empty),
-                        KeyValuePair.Create(nameof(query.ServiceNameFilter), query.ServiceNameFilter != null ? query.ServiceNameFilter.ToString() : string.Empty),
-                        KeyValuePair.Create("page", (pageIndex++).ToString()),
-                    });
+                var page = await FabricCallHelper.RunWithExponentialRetries(
+                    (attempt, cancellationToken) => this.operationLogger.ExecuteAsync(
+                        "FabricApi.GetServicePagedListAsync",
+                        () => this.queryClient.GetServicePagedListAsync(
+                                serviceQueryDescription: query,
+                                timeout: eachApiCallTimeout,
+                                cancellationToken: cancellationToken),
+                        new[]
+                        {
+                            KeyValuePair.Create(nameof(query.ServiceTypeNameFilter), query.ServiceTypeNameFilter ?? string.Empty),
+                            KeyValuePair.Create(nameof(query.ServiceNameFilter), query.ServiceNameFilter != null ? query.ServiceNameFilter.ToString() : string.Empty),
+                            KeyValuePair.Create("page", pageIndex.ToString()),
+                            KeyValuePair.Create("attempt", attempt.ToString()),
+                        }),
+                    FabricExponentialRetryPolicy.Default,
+                    cancellationToken);
 
+                pageIndex++;
                 foreach (var item in page)
                 {
                     yield return new ServiceWrapper
@@ -228,23 +233,25 @@ namespace IslandGateway.FabricDiscovery.FabricWrapper
             string continuationToken = null;
             do
             {
-                var page = await this.operationLogger.ExecuteAsync(
-                    "FabricApi.GetPartitionListAsync",
-                    () => ExceptionsHelper.TranslateCancellations(
-                        func: static state => state.queryClient.GetPartitionListAsync(
-                            serviceName: state.serviceName,
+                var page = await FabricCallHelper.RunWithExponentialRetries(
+                    (attempt, cancellationToken) => this.operationLogger.ExecuteAsync(
+                        "FabricApi.GetPartitionListAsync",
+                        () => this.queryClient.GetPartitionListAsync(
+                            serviceName: serviceName,
                             partitionIdFilter: null,
-                            continuationToken: state.continuationToken,
-                            timeout: state.eachApiCallTimeout,
-                            cancellationToken: state.cancellationToken),
-                        state: (this.queryClient, serviceName, continuationToken, eachApiCallTimeout, cancellationToken),
-                        cancellation: cancellationToken),
-                    new[]
-                    {
-                        KeyValuePair.Create(nameof(serviceName), serviceName.ToString() ?? string.Empty),
-                        KeyValuePair.Create("page", (pageIndex++).ToString()),
-                    });
+                            continuationToken: continuationToken,
+                            timeout: eachApiCallTimeout,
+                            cancellationToken: cancellationToken),
+                        new[]
+                        {
+                            KeyValuePair.Create(nameof(serviceName), serviceName.ToString() ?? string.Empty),
+                            KeyValuePair.Create("page", pageIndex.ToString()),
+                            KeyValuePair.Create("attempt", attempt.ToString()),
+                        }),
+                    FabricExponentialRetryPolicy.Default,
+                    cancellationToken);
 
+                pageIndex++;
                 foreach (var item in page)
                 {
                     yield return new PartitionWrapper
@@ -265,22 +272,24 @@ namespace IslandGateway.FabricDiscovery.FabricWrapper
             string continuationToken = null;
             do
             {
-                var page = await this.operationLogger.ExecuteAsync(
-                    "FabricApi.GetReplicaListAsync",
-                    () => ExceptionsHelper.TranslateCancellations(
-                        func: static state => state.queryClient.GetReplicaListAsync(
-                            partitionId: state.partitionId,
-                            continuationToken: state.continuationToken,
-                            timeout: state.eachApiCallTimeout,
-                            cancellationToken: state.cancellationToken),
-                        state: (this.queryClient, partitionId, eachApiCallTimeout, continuationToken, cancellationToken),
-                        cancellationToken),
-                    new[]
-                    {
-                        KeyValuePair.Create(nameof(partitionId), partitionId.ToString()),
-                        KeyValuePair.Create("page", (pageIndex++).ToString()),
-                    });
+                var page = await FabricCallHelper.RunWithExponentialRetries(
+                    (attempt, cancellationToken) => this.operationLogger.ExecuteAsync(
+                        "FabricApi.GetReplicaListAsync",
+                        () => this.queryClient.GetReplicaListAsync(
+                            partitionId: partitionId,
+                            continuationToken: continuationToken,
+                            timeout: eachApiCallTimeout,
+                            cancellationToken: cancellationToken),
+                        new[]
+                        {
+                            KeyValuePair.Create(nameof(partitionId), partitionId.ToString()),
+                            KeyValuePair.Create("page", pageIndex.ToString()),
+                            KeyValuePair.Create("attempt", attempt.ToString()),
+                        }),
+                    FabricExponentialRetryPolicy.Default,
+                    cancellationToken);
 
+                pageIndex++;
                 foreach (var item in page)
                 {
                     yield return new ReplicaWrapper

--- a/test/FabricDiscovery.Core.Tests/Service/Util/FabricCallHelperTests.cs
+++ b/test/FabricDiscovery.Core.Tests/Service/Util/FabricCallHelperTests.cs
@@ -1,0 +1,154 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Fabric;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IslandGateway.ServiceFabricIntegration;
+using Xunit;
+
+namespace IslandGateway.FabricDiscovery.Util.Tests
+{
+    public class FabricCallHelperTests
+    {
+        [Fact]
+        public async Task RunWithRetries_FirstAttemptSucceeds()
+        {
+            // Arrange
+            var attempts = new List<int>();
+
+            // Act
+            var result = await FabricCallHelper.RunWithExponentialRetries(
+                async (attempt, _) =>
+                {
+                    attempts.Add(attempt);
+
+                    await Task.Yield();
+                    return "ok";
+                },
+                FabricExponentialRetryPolicy.Default,
+                CancellationToken.None);
+
+            // Assert
+            attempts.Should().Equal(new[] { 1 });
+            result.Should().Be("ok");
+        }
+
+        [Fact]
+        public async Task RetryTransientFailures_RetriesTransientErrors()
+        {
+            // Arrange
+            var attempts = new List<int>();
+
+            // Act
+            var result = await FabricCallHelper.RunWithExponentialRetries(
+                async (attempt, _) =>
+                {
+                    attempts.Add(attempt);
+
+                    await Task.Yield();
+                    if (attempt == 1)
+                    {
+                        throw new TimeoutException("transient");
+                    }
+                    else if (attempt == 2)
+                    {
+                        throw new FabricTransientException();
+                    }
+
+                    return "ok";
+                },
+                FabricExponentialRetryPolicy.Default,
+                CancellationToken.None);
+
+            // Assert
+            attempts.Should().Equal(new[] { 1, 2, 3 });
+            result.Should().Be("ok");
+        }
+
+        [Fact]
+        public async Task RetryTransientFailures_DoesNotRetryNonTransient()
+        {
+            // Arrange
+            var attempts = new List<int>();
+
+            // Act
+            Func<Task> func = () => FabricCallHelper.RunWithExponentialRetries<string>(
+                async (attempt, _) =>
+                {
+                    attempts.Add(attempt);
+
+                    await Task.Yield();
+                    throw new Exception("boom");
+                },
+                FabricExponentialRetryPolicy.Default,
+                CancellationToken.None);
+
+            // Assert
+            await func.Should().ThrowAsync<Exception>().WithMessage("boom");
+            attempts.Should().Equal(new[] { 1 });
+        }
+
+        [Fact]
+        public async Task RetryTransientFailures_TranslatesDeliberateCancellations()
+        {
+            // Arrange
+            var attempts = new List<int>();
+            using var cts = new CancellationTokenSource();
+            var tcs1 = new TaskCompletionSource<int>();
+            var tcs2 = new TaskCompletionSource<int>();
+
+            // Act
+            var task = FabricCallHelper.RunWithExponentialRetries<string>(
+                async (attempt, _) =>
+                {
+                    attempts.Add(attempt);
+
+                    await Task.Yield();
+                    tcs1.SetResult(0);
+
+                    await tcs2.Task;
+                    throw new FabricTransientException(FabricErrorCode.OperationCanceled);
+                },
+                FabricExponentialRetryPolicy.Default,
+                cts.Token);
+
+            await tcs1.Task;
+
+            cts.Cancel();
+            tcs2.SetResult(0);
+
+            Func<Task> func = () => task;
+
+            // Assert
+            await func.Should().ThrowAsync<OperationCanceledException>();
+            attempts.Should().Equal(new[] { 1 });
+        }
+
+        [Fact]
+        public async Task RunWithRetries_AbortsWhenCanceled()
+        {
+            // Arrange
+            var attempts = new List<int>();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // Act
+            Func<Task> func = () => FabricCallHelper.RunWithExponentialRetries<string>(
+                (attempt, _) =>
+                {
+                    attempts.Add(attempt);
+                    throw new Exception("Execvution should never get here.");
+                },
+                FabricExponentialRetryPolicy.Default,
+                cts.Token);
+
+            // Assert
+            await func.Should().ThrowAsync<OperationCanceledException>();
+            attempts.Should().BeEmpty();
+        }
+    }
+}

--- a/test/FabricDiscovery.Core.Tests/Service/Util/FabricExponentialRetryPolicyTests.cs
+++ b/test/FabricDiscovery.Core.Tests/Service/Util/FabricExponentialRetryPolicyTests.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using FluentAssertions;
+using IslandGateway.ServiceFabricIntegration;
+using Xunit;
+
+namespace IslandGateway.FabricDiscovery.Util.Tests
+{
+    public class FabricExponentialRetryPolicyTests
+    {
+        [Fact]
+        public void RetryPolicy_ValidatesParams()
+        {
+            // Arrange
+            var fabricRetryPolicy = new FabricExponentialRetryPolicy
+            {
+                NumAttempts = 3,
+                InitialBackoffMs = 1000,
+                MaxBackoffMs = 15000,
+            };
+
+            // + Act + Assert
+            Assert.Throws<ArgumentOutOfRangeException>(() => fabricRetryPolicy.IsRetryAllowed(0, out var _));
+            Assert.Throws<ArgumentOutOfRangeException>(() => fabricRetryPolicy.IsRetryAllowed(-100, out var _));
+        }
+
+        [Fact]
+        public void RetryPolicy_CorrectlyCalculatesBackoff()
+        {
+            // Arrange
+            var fabricRetryPolicy = new FabricExponentialRetryPolicy
+            {
+                NumAttempts = 6,
+                InitialBackoffMs = 1000,
+                MaxBackoffMs = 15000,
+            };
+
+            // Act + Assert
+            fabricRetryPolicy.IsRetryAllowed(1, out int backoff).Should().Be(true);
+            backoff.Should().Be(1000);
+            fabricRetryPolicy.IsRetryAllowed(2, out backoff).Should().Be(true);
+            backoff.Should().Be(3000);
+            fabricRetryPolicy.IsRetryAllowed(3, out backoff).Should().Be(true);
+            backoff.Should().Be(7000);
+            fabricRetryPolicy.IsRetryAllowed(4, out backoff).Should().Be(true);
+            backoff.Should().Be(15000);
+            fabricRetryPolicy.IsRetryAllowed(5, out backoff).Should().Be(true);
+            backoff.Should().Be(15000); // reached max backoff
+            fabricRetryPolicy.IsRetryAllowed(6, out backoff).Should().Be(false);
+            backoff.Should().Be(default);
+        }
+    }
+}


### PR DESCRIPTION
This PR contains multiple PRs from the CoreServicesGateway repo:

* 4918967: `page` logged incorrectly in SF api operations
* 4922018: RecurringTask: treat iteration timeout as failure
* 4863446: Retry SF api calls on transient errors
* 5007617: FabricDiscovery: Exponential retry for FabricCallHelper